### PR TITLE
Add RBAC client support and registry/type updates

### DIFF
--- a/pkg/client/rbac.go
+++ b/pkg/client/rbac.go
@@ -1,0 +1,328 @@
+/*
+ *  *******************************************************************************
+ *  * Copyright (c) 2024 Datasance Teknoloji A.S.
+ *  *
+ *  * This program and the accompanying materials are made available under the
+ *  * terms of the Eclipse Public License v. 2.0 which is available at
+ *  * http://www.eclipse.org/legal/epl-2.0
+ *  *
+ *  * SPDX-License-Identifier: EPL-2.0
+ *  *******************************************************************************
+ *
+ */
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+)
+
+// Roles
+
+// ListRoles retrieves all roles from the Controller REST API
+func (clt *Client) ListRoles() (*RoleListResponse, error) {
+	body, err := clt.doRequest("GET", "/roles", nil)
+	if err != nil {
+		return nil, err
+	}
+	response := new(RoleListResponse)
+	if err = json.Unmarshal(body, response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// GetRole retrieves a single role by name from the Controller REST API
+func (clt *Client) GetRole(name string) (*RoleInfo, error) {
+	body, err := clt.doRequest("GET", fmt.Sprintf("/roles/%s", name), nil)
+	if err != nil {
+		return nil, err
+	}
+	response := new(RoleResponse)
+	if err = json.Unmarshal(body, response); err != nil {
+		return nil, err
+	}
+	return &response.Role, nil
+}
+
+// CreateRole creates a new role using the Controller REST API
+func (clt *Client) CreateRole(request *RoleCreateRequest) (*RoleInfo, error) {
+	body, err := clt.doRequest("POST", "/roles", request)
+	if err != nil {
+		return nil, err
+	}
+	response := new(RoleResponse)
+	if err = json.Unmarshal(body, response); err != nil {
+		return nil, err
+	}
+	return &response.Role, nil
+}
+
+// CreateRoleFromYaml creates a role from a YAML file using the Controller REST API
+func (clt *Client) CreateRoleFromYaml(file io.Reader) error {
+	requestBody := &bytes.Buffer{}
+	writer := multipart.NewWriter(requestBody)
+	part, err := writer.CreateFormFile("role", "role.yaml")
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(part, file)
+	if err != nil {
+		return err
+	}
+	writer.Close()
+
+	headers := map[string]string{
+		"Content-Type": writer.FormDataContentType(),
+	}
+	_, err = clt.doRequestWithHeaders("POST", "/roles/yaml", requestBody, headers)
+	return err
+}
+
+// UpdateRole updates a role by name using the Controller REST API
+func (clt *Client) UpdateRole(name string, request *RoleUpdateRequest) (*RoleInfo, error) {
+	body, err := clt.doRequest("PATCH", fmt.Sprintf("/roles/%s", name), request)
+	if err != nil {
+		return nil, err
+	}
+	response := new(RoleResponse)
+	if err = json.Unmarshal(body, response); err != nil {
+		return nil, err
+	}
+	return &response.Role, nil
+}
+
+// UpdateRoleFromYaml updates a role from a YAML file using the Controller REST API
+func (clt *Client) UpdateRoleFromYaml(name string, file io.Reader) error {
+	requestBody := &bytes.Buffer{}
+	writer := multipart.NewWriter(requestBody)
+	part, err := writer.CreateFormFile("role", "role.yaml")
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(part, file)
+	if err != nil {
+		return err
+	}
+	writer.Close()
+
+	headers := map[string]string{
+		"Content-Type": writer.FormDataContentType(),
+	}
+	_, err = clt.doRequestWithHeaders("PATCH", fmt.Sprintf("/roles/yaml/%s", name), requestBody, headers)
+	return err
+}
+
+// DeleteRole deletes a role by name using the Controller REST API
+func (clt *Client) DeleteRole(name string) error {
+	_, err := clt.doRequest("DELETE", fmt.Sprintf("/roles/%s", name), nil)
+	return err
+}
+
+// RoleBindings
+
+// ListRoleBindings retrieves all role bindings from the Controller REST API
+func (clt *Client) ListRoleBindings() (*RoleBindingListResponse, error) {
+	body, err := clt.doRequest("GET", "/rolebindings", nil)
+	if err != nil {
+		return nil, err
+	}
+	response := new(RoleBindingListResponse)
+	if err = json.Unmarshal(body, response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// GetRoleBinding retrieves a single role binding by name from the Controller REST API
+func (clt *Client) GetRoleBinding(name string) (*RoleBindingInfo, error) {
+	body, err := clt.doRequest("GET", fmt.Sprintf("/rolebindings/%s", name), nil)
+	if err != nil {
+		return nil, err
+	}
+	response := new(RoleBindingResponse)
+	if err = json.Unmarshal(body, response); err != nil {
+		return nil, err
+	}
+	return &response.Binding, nil
+}
+
+// CreateRoleBinding creates a new role binding using the Controller REST API
+func (clt *Client) CreateRoleBinding(request *RoleBindingCreateRequest) (*RoleBindingInfo, error) {
+	body, err := clt.doRequest("POST", "/rolebindings", request)
+	if err != nil {
+		return nil, err
+	}
+	response := new(RoleBindingResponse)
+	if err = json.Unmarshal(body, response); err != nil {
+		return nil, err
+	}
+	return &response.Binding, nil
+}
+
+// CreateRoleBindingFromYaml creates a role binding from a YAML file using the Controller REST API
+func (clt *Client) CreateRoleBindingFromYaml(file io.Reader) error {
+	requestBody := &bytes.Buffer{}
+	writer := multipart.NewWriter(requestBody)
+	part, err := writer.CreateFormFile("rolebinding", "rolebinding.yaml")
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(part, file)
+	if err != nil {
+		return err
+	}
+	writer.Close()
+
+	headers := map[string]string{
+		"Content-Type": writer.FormDataContentType(),
+	}
+	_, err = clt.doRequestWithHeaders("POST", "/rolebindings/yaml", requestBody, headers)
+	return err
+}
+
+// UpdateRoleBinding updates a role binding by name using the Controller REST API
+func (clt *Client) UpdateRoleBinding(name string, request *RoleBindingUpdateRequest) (*RoleBindingInfo, error) {
+	body, err := clt.doRequest("PATCH", fmt.Sprintf("/rolebindings/%s", name), request)
+	if err != nil {
+		return nil, err
+	}
+	response := new(RoleBindingResponse)
+	if err = json.Unmarshal(body, response); err != nil {
+		return nil, err
+	}
+	return &response.Binding, nil
+}
+
+// UpdateRoleBindingFromYaml updates a role binding from a YAML file using the Controller REST API
+func (clt *Client) UpdateRoleBindingFromYaml(name string, file io.Reader) error {
+	requestBody := &bytes.Buffer{}
+	writer := multipart.NewWriter(requestBody)
+	part, err := writer.CreateFormFile("rolebinding", "rolebinding.yaml")
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(part, file)
+	if err != nil {
+		return err
+	}
+	writer.Close()
+
+	headers := map[string]string{
+		"Content-Type": writer.FormDataContentType(),
+	}
+	_, err = clt.doRequestWithHeaders("PATCH", fmt.Sprintf("/rolebindings/yaml/%s", name), requestBody, headers)
+	return err
+}
+
+// DeleteRoleBinding deletes a role binding by name using the Controller REST API
+func (clt *Client) DeleteRoleBinding(name string) error {
+	_, err := clt.doRequest("DELETE", fmt.Sprintf("/rolebindings/%s", name), nil)
+	return err
+}
+
+// ServiceAccounts
+
+// ListServiceAccounts retrieves all service accounts from the Controller REST API
+func (clt *Client) ListServiceAccounts() (*ServiceAccountListResponse, error) {
+	body, err := clt.doRequest("GET", "/serviceaccounts", nil)
+	if err != nil {
+		return nil, err
+	}
+	response := new(ServiceAccountListResponse)
+	if err = json.Unmarshal(body, response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// GetServiceAccount retrieves a single service account by name from the Controller REST API
+func (clt *Client) GetServiceAccount(name string) (*ServiceAccountInfo, error) {
+	body, err := clt.doRequest("GET", fmt.Sprintf("/serviceaccounts/%s", name), nil)
+	if err != nil {
+		return nil, err
+	}
+	response := new(ServiceAccountResponse)
+	if err = json.Unmarshal(body, response); err != nil {
+		return nil, err
+	}
+	return &response.ServiceAccount, nil
+}
+
+// CreateServiceAccount creates a new service account using the Controller REST API
+func (clt *Client) CreateServiceAccount(request *ServiceAccountCreateRequest) (*ServiceAccountInfo, error) {
+	body, err := clt.doRequest("POST", "/serviceaccounts", request)
+	if err != nil {
+		return nil, err
+	}
+	response := new(ServiceAccountResponse)
+	if err = json.Unmarshal(body, response); err != nil {
+		return nil, err
+	}
+	return &response.ServiceAccount, nil
+}
+
+// CreateServiceAccountFromYaml creates a service account from a YAML file using the Controller REST API
+func (clt *Client) CreateServiceAccountFromYaml(file io.Reader) error {
+	requestBody := &bytes.Buffer{}
+	writer := multipart.NewWriter(requestBody)
+	part, err := writer.CreateFormFile("serviceaccount", "serviceaccount.yaml")
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(part, file)
+	if err != nil {
+		return err
+	}
+	writer.Close()
+
+	headers := map[string]string{
+		"Content-Type": writer.FormDataContentType(),
+	}
+	_, err = clt.doRequestWithHeaders("POST", "/serviceaccounts/yaml", requestBody, headers)
+	return err
+}
+
+// UpdateServiceAccount updates a service account by name using the Controller REST API
+func (clt *Client) UpdateServiceAccount(name string, request *ServiceAccountUpdateRequest) (*ServiceAccountInfo, error) {
+	body, err := clt.doRequest("PATCH", fmt.Sprintf("/serviceaccounts/%s", name), request)
+	if err != nil {
+		return nil, err
+	}
+	response := new(ServiceAccountResponse)
+	if err = json.Unmarshal(body, response); err != nil {
+		return nil, err
+	}
+	return &response.ServiceAccount, nil
+}
+
+// UpdateServiceAccountFromYaml updates a service account from a YAML file using the Controller REST API
+func (clt *Client) UpdateServiceAccountFromYaml(name string, file io.Reader) error {
+	requestBody := &bytes.Buffer{}
+	writer := multipart.NewWriter(requestBody)
+	part, err := writer.CreateFormFile("serviceaccount", "serviceaccount.yaml")
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(part, file)
+	if err != nil {
+		return err
+	}
+	writer.Close()
+
+	headers := map[string]string{
+		"Content-Type": writer.FormDataContentType(),
+	}
+	_, err = clt.doRequestWithHeaders("PATCH", fmt.Sprintf("/serviceaccounts/yaml/%s", name), requestBody, headers)
+	return err
+}
+
+// DeleteServiceAccount deletes a service account by name using the Controller REST API
+func (clt *Client) DeleteServiceAccount(name string) error {
+	_, err := clt.doRequest("DELETE", fmt.Sprintf("/serviceaccounts/%s", name), nil)
+	return err
+}

--- a/pkg/client/registries.go
+++ b/pkg/client/registries.go
@@ -40,6 +40,19 @@ func (clt *Client) UpdateRegistry(request RegistryUpdateRequest) error {
 	return nil
 }
 
+// GetRegistry retrieves a single registry by ID from the Controller REST API
+func (clt *Client) GetRegistry(id int) (*RegistryInfo, error) {
+	body, err := clt.doRequest("GET", fmt.Sprintf("/registries/%d", id), nil)
+	if err != nil {
+		return nil, err
+	}
+	registry := new(RegistryInfo)
+	if err := json.Unmarshal(body, registry); err != nil {
+		return nil, err
+	}
+	return registry, nil
+}
+
 // ListRegistries retrieve all registries information from the Controller REST API
 func (clt *Client) ListRegistries() (response RegistryListResponse, err error) {
 	body, err := clt.doRequest("GET", "/registries", nil)

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -122,6 +122,7 @@ type RegistryInfo struct {
 	RequiresCert bool   `json:"requiresCert"`
 	Username     string `json:"username"`
 	Email        string `json:"userEmail"`
+	Password     string `json:"password"`
 }
 
 type RegistryCreateRequest struct {
@@ -151,6 +152,124 @@ type RegistryUpdateRequest struct {
 
 type RegistryListResponse struct {
 	Registries []RegistryInfo `json:"registries"`
+}
+
+// RBAC
+
+// RBACRule is a single rule in a Role (apiGroups, resources, verbs, optional resourceNames)
+type RBACRule struct {
+	APIGroups     []string `json:"apiGroups"`
+	Resources     []string `json:"resources"`
+	Verbs         []string `json:"verbs"`
+	ResourceNames []string `json:"resourceNames,omitempty"`
+}
+
+// RoleRef references a Role by kind and name
+type RoleRef struct {
+	Kind     string `json:"kind"`
+	Name     string `json:"name"`
+	APIGroup string `json:"apiGroup,omitempty"`
+}
+
+// Subject is a user, group, or service account in a RoleBinding
+type Subject struct {
+	Kind     string `json:"kind"`
+	Name     string `json:"name"`
+	APIGroup string `json:"apiGroup,omitempty"`
+}
+
+// RoleInfo is a Role as returned by the API
+type RoleInfo struct {
+	Name  string     `json:"name"`
+	Kind  string     `json:"kind,omitempty"`
+	Rules []RBACRule `json:"rules"`
+}
+
+// RoleCreateRequest is the request body for creating a Role
+type RoleCreateRequest struct {
+	Name  string     `json:"name"`
+	Kind  string     `json:"kind,omitempty"`
+	Rules []RBACRule `json:"rules"`
+}
+
+// RoleUpdateRequest is the request body for updating a Role
+type RoleUpdateRequest struct {
+	Name  *string    `json:"name,omitempty"`
+	Kind  string     `json:"kind,omitempty"`
+	Rules []RBACRule `json:"rules"`
+}
+
+// RoleListResponse is the response for listing roles
+type RoleListResponse struct {
+	Roles []RoleInfo `json:"roles"`
+}
+
+// RoleResponse is the response for get/create/update role (single role wrapped)
+type RoleResponse struct {
+	Role RoleInfo `json:"role"`
+}
+
+// RoleBindingInfo is a RoleBinding as returned by the API
+type RoleBindingInfo struct {
+	Name     string    `json:"name"`
+	Kind     string    `json:"kind,omitempty"`
+	RoleRef  RoleRef   `json:"roleRef"`
+	Subjects []Subject `json:"subjects"`
+}
+
+// RoleBindingCreateRequest is the request body for creating a RoleBinding
+type RoleBindingCreateRequest struct {
+	Name     string    `json:"name"`
+	Kind     string    `json:"kind,omitempty"`
+	RoleRef  RoleRef   `json:"roleRef"`
+	Subjects []Subject `json:"subjects"`
+}
+
+// RoleBindingUpdateRequest is the request body for updating a RoleBinding
+type RoleBindingUpdateRequest struct {
+	Name     *string   `json:"name,omitempty"`
+	Kind     string    `json:"kind,omitempty"`
+	RoleRef  RoleRef   `json:"roleRef"`
+	Subjects []Subject `json:"subjects"`
+}
+
+// RoleBindingListResponse is the response for listing role bindings
+type RoleBindingListResponse struct {
+	Bindings []RoleBindingInfo `json:"bindings"`
+}
+
+// RoleBindingResponse is the response for get/create/update role binding
+type RoleBindingResponse struct {
+	Binding RoleBindingInfo `json:"binding"`
+}
+
+// ServiceAccountInfo is a ServiceAccount as returned by the API
+type ServiceAccountInfo struct {
+	ID      int     `json:"id,omitempty"`
+	Name    string  `json:"name"`
+	RoleRef RoleRef `json:"roleRef"`
+}
+
+// ServiceAccountCreateRequest is the request body for creating a ServiceAccount
+type ServiceAccountCreateRequest struct {
+	Name    string  `json:"name"`
+	RoleRef RoleRef `json:"roleRef"`
+}
+
+// ServiceAccountUpdateRequest is the request body for updating a ServiceAccount
+type ServiceAccountUpdateRequest struct {
+	Name    string  `json:"name"`
+	RoleRef RoleRef `json:"roleRef"`
+}
+
+// ServiceAccountListResponse is the response for listing service accounts
+type ServiceAccountListResponse struct {
+	ServiceAccounts []ServiceAccountInfo `json:"serviceAccounts"`
+}
+
+// ServiceAccountResponse is the response for get/create/update service account
+type ServiceAccountResponse struct {
+	ServiceAccount ServiceAccountInfo `json:"serviceAccount"`
 }
 
 // Catalog (Keeping it basic, because it will be reworked soon)


### PR DESCRIPTION
Introduce a new RBAC client (pkg/client/rbac.go) with full CRUD for roles, role bindings, and service accounts (including YAML create/update). Add GetRegistry(id) in registries.go, extend RegistryInfo with a Password field, and define RBAC request/response types in types.go.